### PR TITLE
toggleHud

### DIFF
--- a/DisplayCoordinates/DisplayCoordinates.csproj
+++ b/DisplayCoordinates/DisplayCoordinates.csproj
@@ -56,6 +56,9 @@
 		<Reference Include="UnityEngine.TextRenderingModule">
 			<HintPath>C:\Program Files (x86)\Steam\steamapps\common\Wild Skies\BepInEx\interop\UnityEngine.TextRenderingModule.dll</HintPath>
 		</Reference>
+		<Reference Include="Unity.InputSystem">
+			<HintPath>C:\Program Files (x86)\Steam\steamapps\common\Wild Skies\BepInEx\interop\Unity.InputSystem.dll</HintPath>
+		</Reference>
 	</ItemGroup>
 
 

--- a/DisplayCoordinates/HotkeyParser.cs
+++ b/DisplayCoordinates/HotkeyParser.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine.InputSystem;
+
+namespace DisplayCoordinates
+{
+    /// <summary>
+    /// Class that represents a hotkey: key combination + action + press state
+    /// </summary>
+    public class Hotkey
+    {
+        public List<Key> keys;
+        public Action action;
+        public bool pressed; // flag to prevent multiple triggers while the key is held down
+
+        public Hotkey(List<Key> keys, Action action)
+        {
+            this.keys = keys ?? throw new ArgumentNullException(nameof(keys));
+            this.action = action ?? throw new ArgumentNullException(nameof(action));
+            this.pressed = false;
+        }
+    }
+
+    /// <summary>
+    /// Static class to parse hotkey strings into lists of Keys, with fallback to default
+    /// </summary>
+    public static class HotkeyParser
+    {
+        /// <summary>
+        /// Converts a string in the format "LeftCtrl + LeftShift + Delete" to a List<Key>.
+        /// If an invalid key is found, returns the default combination.
+        /// </summary>
+        /// <param name="hotkeyString">Hotkey string</param>
+        /// <param name="defaultCombination">Fallback in case of invalid input</param>
+        /// <returns>Valid list of Keys</returns>
+        public static List<Key> ParseHotkeyString(string hotkeyString, List<Key> defaultCombination)
+        {
+            if (string.IsNullOrWhiteSpace(hotkeyString))
+                return defaultCombination;
+
+            var keys = new List<Key>();
+            var parts = hotkeyString.Split(new[] { '+' }, StringSplitOptions.RemoveEmptyEntries);
+
+            foreach (var part in parts)
+            {
+                string keyString = part.Trim();
+
+                if (Enum.TryParse<Key>(keyString, ignoreCase: true, out Key key))
+                    keys.Add(key);
+                else
+                {
+                    Plugin.mls.LogWarning($"HotkeyParser: Invalid key '{keyString}' in string '{hotkeyString}'. Using default.");
+                    return defaultCombination;
+                }
+            }
+            return keys.Count > 0 ? keys : defaultCombination;
+        }
+    }
+}

--- a/DisplayCoordinates/PlayerCoordinatesBox.cs
+++ b/DisplayCoordinates/PlayerCoordinatesBox.cs
@@ -5,78 +5,81 @@ using System.Collections.Generic;
 using System.Drawing;
 using System;
 
-public class PlayerCoordinatesBox : MonoBehaviour
+namespace DisplayCoordinates
 {
-    private List<Hotkey> hotkeys = new List<Hotkey>();
-
-    void Start()
+    public class PlayerCoordinatesBox : MonoBehaviour
     {
-        string showCoordsString = Plugin.toggleHotkey.Value; // Hotkeys
+        private List<Hotkey> hotkeys = new List<Hotkey>();
 
-        // Default hotkey if keys defined by users fails
-        var showCoordsDefault = new List<Key> { Key.Insert };
-
-        // strings to key list for fallback
-        var showCoordsKeys = HotkeyParser.ParseHotkeyString(showCoordsString, showCoordsDefault);
-
-        // Added the hotkey with the command to exec if pressed
-        hotkeys.Add(new Hotkey(showCoordsKeys, () =>
+        void Start()
         {
-            Plugin.showCoords.Value = !Plugin.showCoords.Value; // Toggles the value of showCoords
-            Plugin.configFile.Save(); // Saves the .cfg file
-            Plugin.mls.LogInfo($"Hotkey pressed! showCoords is now: {Plugin.showCoords.Value} (Frame: {Time.frameCount})");
-        }));
-    }
+            string showCoordsString = Plugin.toggleHotkey.Value; // Hotkeys
 
-    void Update()
-    {
-        foreach (var hotkey in hotkeys)
-        {
-            if (IsHotkeyPressed(hotkey))
+            // Default hotkey if keys defined by users fails
+            var showCoordsDefault = new List<Key> { Key.Insert };
+
+            // strings to key list for fallback
+            var showCoordsKeys = HotkeyParser.ParseHotkeyString(showCoordsString, showCoordsDefault);
+
+            // Added the hotkey with the command to exec if pressed
+            hotkeys.Add(new Hotkey(showCoordsKeys, () =>
             {
-                if (!hotkey.pressed && Time.time - Plugin.lastActionTime >= Plugin.actionCooldown)
+                Plugin.showCoords.Value = !Plugin.showCoords.Value; // Toggles the value of showCoords
+                Plugin.configFile.Save(); // Saves the .cfg file
+                Plugin.mls.LogInfo($"Hotkey pressed! showCoords is now: {Plugin.showCoords.Value} (Frame: {Time.frameCount})");
+            }));
+        }
+
+        void Update()
+        {
+            foreach (var hotkey in hotkeys)
+            {
+                if (IsHotkeyPressed(hotkey))
                 {
-                    Plugin.lastActionTime = Time.time;
-                    hotkey.action.Invoke();
-                    hotkey.pressed = true;
+                    if (!hotkey.pressed && Time.time - Plugin.lastActionTime >= Plugin.actionCooldown)
+                    {
+                        Plugin.lastActionTime = Time.time;
+                        hotkey.action.Invoke();
+                        hotkey.pressed = true;
+                    }
                 }
-            }
-            else
-            {
-                if (hotkey.pressed)
+                else
                 {
-                    hotkey.pressed = false;
-                    Plugin.mls.LogInfo("Hotkey cleared!");
+                    if (hotkey.pressed)
+                    {
+                        hotkey.pressed = false;
+                        Plugin.mls.LogInfo("Hotkey cleared!");
+                    }
                 }
             }
         }
-    }
 
-    private bool IsHotkeyPressed(Hotkey hotkey)
-    {
-        foreach (var key in hotkey.keys)
+        private bool IsHotkeyPressed(Hotkey hotkey)
         {
-            if (!Keyboard.current[key].isPressed)
-                return false;
+            foreach (var key in hotkey.keys)
+            {
+                if (!Keyboard.current[key].isPressed)
+                    return false;
+            }
+
+            Key lastKey = hotkey.keys[hotkey.keys.Count - 1];
+            return Keyboard.current[lastKey].wasPressedThisFrame;
         }
 
-        Key lastKey = hotkey.keys[hotkey.keys.Count - 1];
-        return Keyboard.current[lastKey].wasPressedThisFrame;
-    }
+        void OnGUI()
+        {
+            if (!Plugin.showCoords.Value) return;
 
-    void OnGUI()
-    {
-        if (!Plugin.showCoords.Value) return;
+            GUIStyle style = new GUIStyle(GUI.skin.box);
+            style.fontSize = Plugin.fontSize;
+            style.alignment = TextAnchor.MiddleCenter;
+            style.normal.textColor = Color.white;
 
-        GUIStyle style = new GUIStyle(GUI.skin.box);
-        style.fontSize = Plugin.fontSize;
-        style.alignment = TextAnchor.MiddleCenter;
-        style.normal.textColor = Color.white;
-
-        GUILayout.BeginArea(Plugin.layoutRect);
-        if (Plugin.showCharName.Value)
-            GUILayout.Box(Plugin.name, style);
-        GUILayout.Box($"x: {Plugin.coords.x:0.00}  y: {Plugin.coords.y:0.00}  z: {Plugin.coords.z:0.00}", style);
-        GUILayout.EndArea();
+            GUILayout.BeginArea(Plugin.layoutRect);
+            if (Plugin.showCharName.Value)
+                GUILayout.Box(Plugin.name, style);
+            GUILayout.Box($"x: {Plugin.coords.x:0.00}  y: {Plugin.coords.y:0.00}  z: {Plugin.coords.z:0.00}", style);
+            GUILayout.EndArea();
+        }
     }
 }

--- a/DisplayCoordinates/PlayerCoordinatesBox.cs
+++ b/DisplayCoordinates/PlayerCoordinatesBox.cs
@@ -1,58 +1,67 @@
 ﻿using DisplayCoordinates;
-using UnityEngine;
 using UnityEngine.InputSystem;
+using UnityEngine;
+using System.Collections.Generic;
+using System.Drawing;
+using System;
 
 public class PlayerCoordinatesBox : MonoBehaviour
 {
-    private bool hotkeyPressed = false; // Flag to check if the key is being held
+    private List<Hotkey> hotkeys = new List<Hotkey>();
+
+    void Start()
+    {
+        string showCoordsString = Plugin.toggleHotkey.Value; // Hotkeys
+
+        // Default hotkey if keys defined by users fails
+        var showCoordsDefault = new List<Key> { Key.Insert };
+
+        // strings to key list for fallback
+        var showCoordsKeys = HotkeyParser.ParseHotkeyString(showCoordsString, showCoordsDefault);
+
+        // Added the hotkey with the command to exec if pressed
+        hotkeys.Add(new Hotkey(showCoordsKeys, () =>
+        {
+            Plugin.showCoords.Value = !Plugin.showCoords.Value; // Toggles the value of showCoords
+            Plugin.configFile.Save(); // Saves the .cfg file
+            Plugin.mls.LogInfo($"Hotkey pressed! showCoords is now: {Plugin.showCoords.Value} (Frame: {Time.frameCount})");
+        }));
+    }
 
     void Update()
     {
-        // Checks if all modifier keys are pressed
-        bool modifiersHeld = AllModifiersHeld();
-
-        // Checks if the primary key was pressed in this frame
-        if (modifiersHeld && PrimaryKeyDown() && !hotkeyPressed)
+        foreach (var hotkey in hotkeys)
         {
-            // Applies cooldown to prevent multiple toggles
-            if (Time.time - Plugin.lastActionTime >= Plugin.actionCooldown)
+            if (IsHotkeyPressed(hotkey))
             {
-                Plugin.lastActionTime = Time.time;
-                Plugin.showCoords.Value = !Plugin.showCoords.Value; // Toggles the value of showCoords
-                Plugin.configFile.Save(); // Saves the .cfg file
-                Plugin.mls.LogInfo($"Hotkey pressed! showCoords is now: {Plugin.showCoords} (Frame: {Time.frameCount})");
-                hotkeyPressed = true; // Marks that the key is being held
+                if (!hotkey.pressed && Time.time - Plugin.lastActionTime >= Plugin.actionCooldown)
+                {
+                    Plugin.lastActionTime = Time.time;
+                    hotkey.action.Invoke();
+                    hotkey.pressed = true;
+                }
             }
-        }
-        // Resets the state when the primary key is released
-        else if (hotkeyPressed && !Keyboard.current[Plugin.primaryKey].isPressed)
-        {
-            hotkeyPressed = false;
-            Plugin.mls.LogInfo("Hotkey liberada!");
+            else
+            {
+                if (hotkey.pressed)
+                {
+                    hotkey.pressed = false;
+                    Plugin.mls.LogInfo("Hotkey cleared!");
+                }
+            }
         }
     }
 
-    bool AllModifiersHeld()
+    private bool IsHotkeyPressed(Hotkey hotkey)
     {
-        bool allModifiersPressed = true;
-        foreach (var modifier in Plugin.modifierKeys)
+        foreach (var key in hotkey.keys)
         {
-            if (!Keyboard.current[modifier].isPressed)
-            {
-                allModifiersPressed = false;
-                break;
-            }
+            if (!Keyboard.current[key].isPressed)
+                return false;
         }
-        return allModifiersPressed;
-    }
 
-    bool PrimaryKeyDown()
-    {
-        // Checks if the primary key was pressed in this frame
-        bool pressed = Keyboard.current[Plugin.primaryKey].wasPressedThisFrame;
-        if (pressed)
-            Plugin.mls.LogInfo($"PrimaryKeyDown detected for {Plugin.primaryKey} (Frame: {Time.frameCount})");
-        return pressed;
+        Key lastKey = hotkey.keys[hotkey.keys.Count - 1];
+        return Keyboard.current[lastKey].wasPressedThisFrame;
     }
 
     void OnGUI()
@@ -60,11 +69,13 @@ public class PlayerCoordinatesBox : MonoBehaviour
         if (!Plugin.showCoords.Value) return;
 
         GUIStyle style = new GUIStyle(GUI.skin.box);
-        style.fontSize = Plugin.fontSize;        
+        style.fontSize = Plugin.fontSize;
+        style.alignment = TextAnchor.MiddleCenter;
         style.normal.textColor = Color.white;
-        style.alignment = TextAnchor.MiddleLeft;
+
         GUILayout.BeginArea(Plugin.layoutRect);
-        GUILayout.Box(Plugin.name, style);
+        if (Plugin.showCharName.Value)
+            GUILayout.Box(Plugin.name, style);
         GUILayout.Box($"x: {Plugin.coords.x:0.00}  y: {Plugin.coords.y:0.00}  z: {Plugin.coords.z:0.00}", style);
         GUILayout.EndArea();
     }

--- a/DisplayCoordinates/PlayerCoordinatesBox.cs
+++ b/DisplayCoordinates/PlayerCoordinatesBox.cs
@@ -1,27 +1,71 @@
-﻿using Il2CppSystem;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using DisplayCoordinates;
 using UnityEngine;
+using UnityEngine.InputSystem;
 
-namespace DisplayCoordinates
+public class PlayerCoordinatesBox : MonoBehaviour
 {
-    internal class PlayerCoordinatesBox : UnityEngine.MonoBehaviour
-    {
-        void OnGUI()
-        {
-            GUIStyle style = new GUIStyle(GUI.skin.box);
-            style.fontSize = Plugin.fontSize;
-            //style.alignment = TextAnchor.MiddleLeft;
-            style.normal.textColor = UnityEngine.Color.white;
+    private bool hotkeyPressed = false; // Flag to check if the key is being held
 
-            GUILayout.BeginArea(Plugin.layoutRect);
-            GUILayout.Box(Plugin.name, style);
-            GUILayout.Box($"x: {Plugin.coords.x:0.00}  y: {Plugin.coords.y:0.00}  z: {Plugin.coords.z:0.00}", style);
-            GUILayout.EndArea();
+    void Update()
+    {
+        // Checks if all modifier keys are pressed
+        bool modifiersHeld = AllModifiersHeld();
+
+        // Checks if the primary key was pressed in this frame
+        if (modifiersHeld && PrimaryKeyDown() && !hotkeyPressed)
+        {
+            // Applies cooldown to prevent multiple toggles
+            if (Time.time - Plugin.lastActionTime >= Plugin.actionCooldown)
+            {
+                Plugin.lastActionTime = Time.time;
+                Plugin.showCoords.Value = !Plugin.showCoords.Value; // Toggles the value of showCoords
+                Plugin.configFile.Save(); // Saves the .cfg file
+                Plugin.mls.LogInfo($"Hotkey pressed! showCoords is now: {Plugin.showCoords} (Frame: {Time.frameCount})");
+                hotkeyPressed = true; // Marks that the key is being held
+            }
+        }
+        // Resets the state when the primary key is released
+        else if (hotkeyPressed && !Keyboard.current[Plugin.primaryKey].isPressed)
+        {
+            hotkeyPressed = false;
+            Plugin.mls.LogInfo("Hotkey liberada!");
         }
     }
+
+    bool AllModifiersHeld()
+    {
+        bool allModifiersPressed = true;
+        foreach (var modifier in Plugin.modifierKeys)
+        {
+            if (!Keyboard.current[modifier].isPressed)
+            {
+                allModifiersPressed = false;
+                break;
+            }
+        }
+        return allModifiersPressed;
+    }
+
+    bool PrimaryKeyDown()
+    {
+        // Checks if the primary key was pressed in this frame
+        bool pressed = Keyboard.current[Plugin.primaryKey].wasPressedThisFrame;
+        if (pressed)
+            Plugin.mls.LogInfo($"PrimaryKeyDown detected for {Plugin.primaryKey} (Frame: {Time.frameCount})");
+        return pressed;
+    }
+
+    void OnGUI()
+    {
+        if (!Plugin.showCoords.Value) return;
+
+        GUIStyle style = new GUIStyle(GUI.skin.box);
+        style.fontSize = Plugin.fontSize;        
+        style.normal.textColor = Color.white;
+        style.alignment = TextAnchor.MiddleLeft;
+        GUILayout.BeginArea(Plugin.layoutRect);
+        GUILayout.Box(Plugin.name, style);
+        GUILayout.Box($"x: {Plugin.coords.x:0.00}  y: {Plugin.coords.y:0.00}  z: {Plugin.coords.z:0.00}", style);
+        GUILayout.EndArea();
+    }
 }
- 

--- a/DisplayCoordinates/Plugin.cs
+++ b/DisplayCoordinates/Plugin.cs
@@ -1,7 +1,11 @@
 ﻿using BepInEx;
+using BepInEx.Configuration;
 using BepInEx.Unity.IL2CPP;
 using HarmonyLib;
 using UnityEngine;
+using System;
+using System.Linq;
+using UnityEngine.InputSystem;
 
 namespace DisplayCoordinates
 {
@@ -11,36 +15,115 @@ namespace DisplayCoordinates
         internal readonly Harmony harmony = new Harmony(MyPluginInfo.PLUGIN_GUID);
         internal static BepInEx.Logging.ManualLogSource mls;
         internal static Vector3 coords;
-        internal static string name="Join the world to see coordinates";
+        internal static string name = "Join the world to see coordinates";
         internal static Rect layoutRect;
         internal static int fontSize;
-
+        internal static ConfigEntry<bool> showCoords;
+        internal static ConfigEntry<string> toggleHotkey;
+        internal static ConfigFile configFile;
+        internal static float lastActionTime;
+        internal const float actionCooldown = 0.5f;
+        internal static Key[] modifierKeys;
+        internal static Key primaryKey;
 
         public override void Load()
         {
             harmony.PatchAll(typeof(Plugin));
             mls = Log;
 
-            int x = Config.Bind<int>("UI", "x", 0, "X position of coordinates box").Value;
-            int y = Config.Bind<int>("UI", "y", 0, "Y position of coordinates box").Value;
-            int width = Config.Bind<int>("UI", "width", 250, "width of coordinates box").Value;
-            int height = Config.Bind<int>("UI", "height", 50, "height of coordinates box").Value;
-            Plugin.fontSize = Config.Bind<int>("UI", "fontSize", 14, "Font size of coordinates").Value;
+            configFile = Config;
+            int x = Config.Bind<int>("UI", "x", 0, "X position of the coordinates box").Value;
+            int y = Config.Bind<int>("UI", "y", 0, "Y position of the coordinates box").Value;
+            int width = Config.Bind<int>("UI", "width", 250, "Width of the coordinates box").Value;
+            int height = Config.Bind<int>("UI", "height", 50, "Height of the coordinates box").Value;
+            fontSize = Config.Bind<int>("UI", "fontSize", 14, "Font size of the coordinates text").Value;
+            showCoords = Config.Bind<bool>("UI", "showCoords", true, "Whether to show coordinates");
+            toggleHotkey = Config.Bind("UI", "toggleHotkey", "Insert", "Use Unity InputSystem Key names (https://docs.unity3d.com/ScriptReference/KeyCode.html), separated by '+'). Examples: RightControl + LeftShift + Insert");
             layoutRect = new Rect(x, y, width, height);
 
+            // Parse hotkeys
+            ParseHotkeyConfig();
+
             IL2CPPChainloader.AddUnityComponent<PlayerCoordinatesBox>();
-            GameObject obj = new();
+            GameObject obj = new GameObject("DisplayCoordinatesManager");
             obj.AddComponent<PlayerCoordinatesBox>();
             GameObject.DontDestroyOnLoad(obj);
 
             Log.LogInfo($"Plugin {MyPluginInfo.PLUGIN_GUID} is loaded!");
         }
 
+        private static void ParseHotkeyConfig()
+        {
+            try
+            {
+                string hotkeyString = toggleHotkey.Value.Trim();
+                if (string.IsNullOrEmpty(hotkeyString))
+                {
+                    mls.LogWarning("Hotkey string is empty. Using default: Insert");
+                    SetDefaultHotkeys();
+                    return;
+                }
+
+                // Split string using " + "
+                string[] keyNames = hotkeyString.Split(new[] { " + " }, StringSplitOptions.RemoveEmptyEntries)
+                                               .Select(k => k.Trim())
+                                               .ToArray();
+
+                if (keyNames.Length < 1)
+                {
+                    mls.LogWarning("No valid keys found in hotkey string. Using default: Insert");
+                    SetDefaultHotkeys();
+                    return;
+                }
+
+                // Last key is primary the others are modifiers
+                string primaryKeyName = keyNames[keyNames.Length - 1];
+                string[] modifierKeyNames = keyNames.Take(keyNames.Length - 1).ToArray();
+
+                // Parse primary key
+                if (!Enum.TryParse<Key>(primaryKeyName, true, out Key parsedPrimaryKey))
+                {
+                    mls.LogWarning($"Invalid primary key '{primaryKeyName}'. Using default: Insert");
+                    SetDefaultHotkeys();
+                    return;
+                }
+                primaryKey = parsedPrimaryKey;
+
+                // Parse modifiers keys
+                modifierKeys = new Key[modifierKeyNames.Length];
+                for (int i = 0; i < modifierKeyNames.Length; i++)
+                {
+                    if (!Enum.TryParse<Key>(modifierKeyNames[i], true, out Key parsedModifier))
+                    {
+                        mls.LogWarning($"Invalid modifier key '{modifierKeyNames[i]}'. Using default: Insert");
+                        SetDefaultHotkeys();
+                        return;
+                    }
+                    modifierKeys[i] = parsedModifier;
+                }
+
+                mls.LogInfo($"Hotkeys parsed successfully: Modifiers=[{string.Join(", ", modifierKeys)}], Primary={primaryKey}");
+            }
+            catch (Exception ex)
+            {
+                mls.LogWarning($"Error parsing hotkey string '{toggleHotkey.Value}': {ex.Message}. Using default: Insert");
+                SetDefaultHotkeys();
+            }
+        }
+
+        private static void SetDefaultHotkeys()
+        {
+            modifierKeys = new Key[] {  };
+            primaryKey = Key.Insert;
+            toggleHotkey.Value = "Insert";
+            configFile.Save();
+        }
+
         [HarmonyPatch(typeof(PlayerNetwork), "Update")]
         [HarmonyPrefix]
         static void Update(PlayerNetwork __instance)
         {
-            if (!__instance.NetworkInstantiated) //if not remote player
+            if (!__instance.NetworkInstantiated)
             {
                 name = __instance.CharacterName;
                 coords = __instance.PlayerSync.PlayerWorldPosition;

--- a/DisplayCoordinates/Plugin.cs
+++ b/DisplayCoordinates/Plugin.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using System;
 using System.Linq;
 using UnityEngine.InputSystem;
+using System.Numerics;
 
 namespace DisplayCoordinates
 {
@@ -19,6 +20,7 @@ namespace DisplayCoordinates
         internal static Rect layoutRect;
         internal static int fontSize;
         internal static ConfigEntry<bool> showCoords;
+        internal static ConfigEntry<bool> showCharName;
         internal static ConfigEntry<string> toggleHotkey;
         internal static ConfigFile configFile;
         internal static float lastActionTime;
@@ -38,6 +40,7 @@ namespace DisplayCoordinates
             int height = Config.Bind<int>("UI", "height", 50, "Height of the coordinates box").Value;
             fontSize = Config.Bind<int>("UI", "fontSize", 14, "Font size of the coordinates text").Value;
             showCoords = Config.Bind<bool>("UI", "showCoords", true, "Whether to show coordinates");
+            showCharName = Config.Bind<bool>("UI", "showCharName", true, "Whether to show char name");
             toggleHotkey = Config.Bind("UI", "toggleHotkey", "Insert", "Use Unity InputSystem Key names (https://docs.unity3d.com/ScriptReference/KeyCode.html), separated by '+'). Examples: RightControl + LeftShift + Insert");
             layoutRect = new Rect(x, y, width, height);
 
@@ -113,7 +116,7 @@ namespace DisplayCoordinates
 
         private static void SetDefaultHotkeys()
         {
-            modifierKeys = new Key[] {  };
+            modifierKeys = new Key[] { };
             primaryKey = Key.Insert;
             toggleHotkey.Value = "Insert";
             configFile.Save();


### PR DESCRIPTION
Added the option to show/hide coordinates by pressing a hotkey. Default: Insert

You can assign more than one key.
You must use Unity KeyCode names: https://docs.unity3d.com/ScriptReference/KeyCode.html
The hotkey is configurable in the config file and multiple keys must be separated by '+'.
Example:
LeftShift + RightControl + Alpha0

Crash prevention:

    Checks for invalid keys and falls back to the default (Insert)

    Adds a small delay between key presses to prevent the toggle from running multiple times